### PR TITLE
feat: Implement Things to Google Tasks migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+# Things to Google Tasks Migrator
+
+This script migrates your tasks and projects from Things 3 (macOS application) to Google Tasks. It reads data directly from the Things 3 SQLite database and uses the Google Tasks API to create corresponding task lists, tasks, and subtasks.
+
+## Features
+
+*   Migrates Things Areas to new Google Task Lists.
+*   Migrates Things Projects to Google Tasks (as main tasks within their respective Area's list).
+*   Migrates tasks within Things Projects (including those under Headings) as subtasks in Google Tasks.
+*   Things Headings are represented as placeholder subtasks under their project task in Google Tasks, with actual tasks under that heading becoming subtasks of the placeholder.
+*   Option to perform a "clean slate" migration by deleting all pre-existing Google Tasks data (task lists and tasks) before starting.
+*   Flexible configuration via command-line arguments or a `config.py` file.
+*   Includes a suite of unit tests to verify functionality.
+
+## Prerequisites
+
+*   Python 3.7+
+*   Access to your Things 3 database file. This script is intended to be run on a macOS machine where Things 3 is installed.
+*   A Google account.
+
+## Setup Instructions
+
+**1. Clone the Repository:**
+```bash
+git clone https://github.com/your-username/things-to-google-tasks.git # Replace with actual URL
+cd things-to-google-tasks
+```
+
+**2. Create a Virtual Environment (Recommended):**
+```bash
+python3 -m venv venv
+source venv/bin/activate  # On Windows use: venv\Scripts\activate
+```
+
+**3. Install Dependencies:**
+```bash
+pip install -r requirements.txt
+```
+
+**4. Set up Google API Credentials:**
+*   Go to the [Google Cloud Console](https://console.cloud.google.com/).
+*   Create a new project or select an existing one.
+*   In the navigation menu, go to "APIs & Services" -> "Library".
+*   Search for "Google Tasks API" and enable it for your project.
+*   Go to "APIs & Services" -> "Credentials".
+*   Click "+ CREATE CREDENTIALS" -> "OAuth client ID".
+*   For "Application type", select "Desktop app".
+*   Give the client ID a name (e.g., "Things Migration Script").
+*   Click "Create". You will see your client ID and client secret.
+*   Click "DOWNLOAD JSON" to download the client secrets file.
+*   **Rename this downloaded file to `credentials.json`** and place it in the root directory of this project. Alternatively, you can specify a different path using command-line arguments or the `config.py` file.
+*   **Authorization:** The first time you run the migration script, it will attempt to open a new tab in your web browser to ask you to authorize access to your Google Tasks. After successful authorization, a `token.json` file will be created in the project's root directory. This file stores your OAuth 2.0 tokens, so you won't need to re-authorize every time you run the script. Keep this file secure.
+
+**5. Configure Things Database Path:**
+*   The script needs access to your Things 3 SQLite database file. The typical path on macOS is:
+    `~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/Things Database/main.sqlite`
+*   You can provide this path to the script in one of two ways:
+    *   **Via `config.py` (Recommended):**
+        Copy the template file:
+        ```bash
+        cp config.py.template config.py
+        ```
+        Edit `config.py` and set the `THINGS_DB_PATH` variable to the correct path of your `main.sqlite` file.
+        You can also set `GOOGLE_API_CREDENTIALS_PATH` in this file if your credentials JSON is not named `credentials.json` or is not in the project root.
+    *   **Via Command-Line Argument:**
+        Use the `--db-path` argument when running the script (see below).
+
+## Running the Migration Script
+
+Ensure your virtual environment is activated if you created one.
+
+**Using `config.py` (Recommended):**
+1.  Make sure you have created `config.py` from `config.py.template` and correctly set `THINGS_DB_PATH` (and `GOOGLE_API_CREDENTIALS_PATH` if needed).
+2.  Run the script:
+    ```bash
+    python src/things_to_google_tasks.py --config-file config.py
+    ```
+
+**Using Command-Line Arguments:**
+```bash
+python src/things_to_google_tasks.py --db-path "/Users/yourusername/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/Things Database/main.sqlite" --creds-path "credentials.json"
+```
+(Replace paths with your actual paths.)
+
+**Clean Slate Option:**
+To delete all existing Google Task Lists and Tasks from your Google account before migrating your Things data, use the `--clean-slate` flag. **Warning: This is irreversible.**
+```bash
+python src/things_to_google_tasks.py --config-file config.py --clean-slate
+```
+Or with direct arguments:
+```bash
+python src/things_to_google_tasks.py --db-path "/path/to/your/main.sqlite" --creds-path "credentials.json" --clean-slate
+```
+You will be prompted for confirmation before any data is deleted.
+
+## Running Unit Tests
+
+To run the included unit tests to ensure the script's components are working correctly:
+```bash
+python -m unittest discover -s tests -p "test_*.py"
+```
+This command should be run from the root directory of the project.
+
+## Project Structure
+
+*   `src/`: Contains the main Python source code.
+    *   `things_reader.py`: Handles reading data from the Things 3 database.
+    *   `google_tasks_client.py`: Manages interactions with the Google Tasks API, including authentication.
+    *   `things_to_google_tasks.py`: The main executable script that orchestrates the migration.
+*   `tests/`: Contains unit tests for the modules in `src/`.
+    *   `test_things_reader.py`
+    *   `test_google_tasks_client.py`
+    *   `test_migration_logic.py`
+*   `requirements.txt`: Lists the Python dependencies required for the project.
+*   `config.py.template`: A template for the configuration file. Copy this to `config.py` to set your database path and (optionally) credentials path.
+*   `credentials.json`: (You create this) Your Google API OAuth 2.0 client secrets.
+*   `token.json`: (Created after first run) Stores your Google API OAuth 2.0 access and refresh tokens.
+*   `README.md`: This file.
+
+## Troubleshooting/Notes
+
+*   **Database Lock:** It's recommended to close the Things 3 application before running the migration script. This helps prevent potential issues with database locking, which might cause the script to fail to read the Things data.
+*   **Google Tasks API Limits:** The Google Tasks API has usage limits (e.g., rate limits on requests). For users with extremely large Things databases (many thousands of tasks and projects), the script might take a significant amount of time to complete or could potentially hit these limits. Currently, the script does not support batching or advanced rate limit handling beyond what the Google client libraries provide.
+*   **First Run Authorization:** Remember that on the first run, your web browser will open to ask for permission to access your Google Tasks. You need to grant this permission for the script to work.
+*   **Standalone Tasks:** Tasks in Things that are not part of any project will be migrated to a Google Task List corresponding to their Area. If a standalone task has no Area, it will be placed in a default list named "Things Imported Tasks".
+*   **Idempotency:**
+    *   Creating Google Task Lists for Areas is idempotent (it checks for existing lists by title).
+    *   Task migration is *not* fully idempotent. Running the script multiple times without the `--clean-slate` option will likely result in duplicate tasks being created in Google Tasks. If you need to re-run the migration, using `--clean-slate` is recommended for a fresh start.
+
+---
+
+Please replace `<repository_url>` and `https://github.com/your-username/things-to-google-tasks.git` with the actual URL of your repository if you plan to host it.

--- a/config.py.template
+++ b/config.py.template
@@ -1,0 +1,14 @@
+# Template for configuration
+# Rename this file to config.py and fill in your actual values
+
+# Path to your Things 3 SQLite database
+# Example for Mac: '/Users/yourusername/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/Things Database/main.sqlite'
+THINGS_DB_PATH = ""
+
+# Path to your Google API credentials JSON file
+# This is the file you download from Google Cloud Console when setting up OAuth 2.0
+GOOGLE_API_CREDENTIALS_PATH = "credentials.json"
+
+# (Optional) Things Cloud credentials, if ever needed by a library (pythings likely won't need this for local DB access)
+# THINGS_EMAIL = ""
+# THINGS_PASSWORD = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib
+peewee

--- a/src/google_tasks_client.py
+++ b/src/google_tasks_client.py
@@ -1,0 +1,377 @@
+import os
+import datetime
+
+# Google API and OAuth libraries
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request # Required for token refresh
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# --- Constants ---
+# Defines the scope of access requested from the Google Tasks API.
+# 'auth/tasks' allows reading and writing tasks and task lists.
+SCOPES = ['https://www.googleapis.com/auth/tasks']
+# Default filename for storing user's OAuth 2.0 access and refresh tokens.
+TOKEN_FILE = 'token.json' 
+
+class GoogleTasksClient:
+    """
+    A client for interacting with the Google Tasks API.
+    Handles authentication, and provides methods for managing task lists and tasks.
+    """
+    def __init__(self, credentials_path="credentials.json"):
+        """
+        Initializes the GoogleTasksClient.
+
+        Args:
+            credentials_path (str): Path to the Google API client secrets JSON file
+                                    (downloaded from Google Cloud Console). Defaults to "credentials.json".
+        
+        Raises:
+            FileNotFoundError: If the `credentials_path` file does not exist when new authentication is required.
+            googleapiclient.errors.HttpError: If building the service client fails.
+        """
+        self.credentials_path = credentials_path
+        self.service = self._authenticate()
+
+    def _authenticate(self):
+        """
+        Authenticates with the Google Tasks API using OAuth 2.0.
+        -   Attempts to load existing credentials from `TOKEN_FILE`.
+        -   If credentials are not found, are invalid, or expired and cannot be refreshed,
+            it initiates the OAuth 2.0 authorization flow.
+        -   Saves valid credentials to `TOKEN_FILE` for future use.
+
+        Returns:
+            googleapiclient.discovery.Resource: An authorized Google Tasks API service instance.
+        
+        Raises:
+            FileNotFoundError: If `self.credentials_path` is not found during the OAuth flow.
+            googleapiclient.errors.HttpError: If building the service client fails after authentication.
+        """
+        creds = None
+        # Step 1: Try to load existing tokens from TOKEN_FILE.
+        # TOKEN_FILE stores the user's access and refresh tokens, and is created
+        # automatically when the authorization flow completes for the first time.
+        if os.path.exists(TOKEN_FILE):
+            creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+        
+        # Step 2: If credentials are not loaded, or are invalid/expired, attempt to refresh or get new ones.
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                # If credentials exist but are expired and have a refresh token, try to refresh them.
+                try:
+                    print("Credentials expired. Attempting to refresh token...")
+                    creds.refresh(Request()) # Request() is from google.auth.transport.requests
+                    print("Token refreshed successfully.")
+                except Exception as e:
+                    print(f"Error refreshing token: {e}. Need to re-authenticate.")
+                    creds = None # Force re-authentication
+            
+            if not creds: # If refresh failed or no token.json, initiate new OAuth flow.
+                print("No valid credentials found. Starting new OAuth 2.0 flow...")
+                if not os.path.exists(self.credentials_path):
+                    # This is a critical error: the client secrets file is needed for OAuth.
+                    raise FileNotFoundError(
+                        f"Credentials file not found at {self.credentials_path}. "
+                        "Please download your OAuth 2.0 client secrets from Google Cloud Console, "
+                        "save it (e.g., as 'credentials.json'), and provide the correct path."
+                    )
+                flow = InstalledAppFlow.from_client_secrets_file(self.credentials_path, SCOPES)
+                # run_local_server will open a browser window for user authorization.
+                creds = flow.run_local_server(port=0)
+                print("OAuth 2.0 flow completed. Credentials obtained.")
+            
+            # Step 3: Save the (newly obtained or refreshed) credentials for the next run.
+            with open(TOKEN_FILE, 'w') as token_file_handle:
+                token_file_handle.write(creds.to_json())
+            print(f"Credentials saved to {TOKEN_FILE}")
+        
+        # Step 4: Build and return the Google Tasks API service client.
+        try:
+            service = build('tasks', 'v1', credentials=creds)
+            print("Google Tasks API service client built successfully.")
+            return service
+        except HttpError as err:
+            # This error can occur if the API is not enabled or other service-level issues.
+            print(f"An API error occurred during service build: {err}")
+            raise 
+
+    def get_task_lists(self):
+        """
+        Fetches all task lists associated with the authenticated user's account.
+
+        Returns:
+            list: A list of task list objects (dictionaries), or an empty list if an error occurs or no lists exist.
+        """
+        try:
+            results = self.service.tasklists().list().execute()
+            return results.get('items', [])
+        except HttpError as err:
+            print(f"An API error occurred while fetching task lists: {err}")
+            return []
+
+    def get_task_list_by_title(self, title):
+        """
+        Finds a specific task list by its title.
+
+        Args:
+            title (str): The title of the task list to find.
+
+        Returns:
+            dict: The task list object if found, otherwise None.
+        """
+        task_lists = self.get_task_lists()
+        for task_list in task_lists:
+            if task_list['title'] == title:
+                return task_list
+        return None
+
+    def create_task_list(self, title):
+        """
+        Creates a new task list with the given title.
+
+        Args:
+            title (str): The title for the new task list.
+
+        Returns:
+            dict: The created task list object, or None if an error occurred.
+        """
+        try:
+            task_list_body = {'title': title}
+            created_list = self.service.tasklists().insert(body=task_list_body).execute()
+            print(f"Task list '{title}' created successfully (ID: {created_list['id']}).")
+            return created_list
+        except HttpError as err:
+            print(f"An API error occurred while creating task list '{title}': {err}")
+            return None
+
+    def delete_task_list(self, task_list_id):
+        """
+        Deletes a task list specified by its ID.
+
+        Args:
+            task_list_id (str): The ID of the task list to delete.
+        """
+        try:
+            self.service.tasklists().delete(tasklist=task_list_id).execute()
+            print(f"Task list ID '{task_list_id}' deleted successfully.")
+        except HttpError as err:
+            # Specifically check for 404 if the list was already deleted or never existed
+            if err.resp.status == 404:
+                print(f"Task list ID '{task_list_id}' not found. Could not delete.")
+            else:
+                print(f"An API error occurred while deleting task list ID '{task_list_id}': {err}")
+
+
+    def clear_all_task_lists_and_tasks(self):
+        """
+        Deletes ALL task lists and ALL tasks within them for the authenticated user.
+        This is a destructive operation.
+        """
+        print("Clearing all task lists and tasks...")
+        task_lists = self.get_task_lists()
+        if not task_lists:
+            print("No task lists found to delete.")
+            return
+
+        for task_list in task_lists:
+            print(f"Deleting task list: {task_list.get('title', 'N/A')} (ID: {task_list['id']})")
+            try:
+                self.delete_task_list(task_list['id'])
+            except HttpError as err:
+                # Log error and continue to try deleting other lists
+                print(f"Failed to delete task list {task_list['id']}: {err}")
+        print("Finished clearing all task lists.")
+
+
+    def create_task(self, task_list_id, title, notes=None, due_date_str=None, parent_task_id=None):
+        """
+        Creates a new task in a specified task list.
+
+        Args:
+            task_list_id (str): The ID of the task list where the task will be created.
+            title (str): The title of the task.
+            notes (str, optional): Optional notes for the task.
+            due_date_str (str, optional): Due date for the task in 'YYYY-MM-DD' format.
+                                       If provided, it will be converted to RFC3339 UTC timestamp
+                                       (e.g., '2023-08-15T00:00:00.000Z').
+            parent_task_id (str, optional): ID of the parent task if creating a subtask.
+
+        Returns:
+            dict: The created task object as returned by the API, or None if an error occurred.
+        """
+        task_body = {'title': title}
+        if notes:
+            task_body['notes'] = notes
+        
+        if due_date_str:
+            try:
+                # Convert 'YYYY-MM-DD' to RFC3339 UTC timestamp format required by Google Tasks API.
+                # Example: '2023-08-15' becomes '2023-08-15T00:00:00.000Z'.
+                # This assumes the due date is for the beginning of the day in UTC.
+                # For tasks due "any time on a day", this is a common representation.
+                dt = datetime.datetime.strptime(due_date_str, '%Y-%m-%d')
+                task_body['due'] = dt.isoformat() + 'Z' 
+            except ValueError:
+                print(f"Warning: Invalid due date format '{due_date_str}'. Please use YYYY-MM-DD. Task will be created without a due date.")
+                # Task creation proceeds without the due date if format is invalid.
+                # Alternatively, one could raise an error or return None here.
+
+        try:
+            if parent_task_id:
+                created_task = self.service.tasks().insert(
+                    tasklist=task_list_id, 
+                    body=task_body,
+                    parent=parent_task_id
+                ).execute()
+            else:
+                 created_task = self.service.tasks().insert(
+                    tasklist=task_list_id, 
+                    body=task_body
+                ).execute()
+            # print(f"Task '{title}' created in list ID '{task_list_id}'.")
+            return created_task
+        except HttpError as err:
+            print(f"An API error occurred while creating task '{title}' in list ID '{task_list_id}': {err}")
+            return None
+
+    def get_tasks_in_list(self, task_list_id, show_completed=False, show_hidden=False):
+        """
+        Fetches tasks from a specified task list.
+
+        Args:
+            task_list_id (str): The ID of the task list.
+            show_completed (bool): Whether to include completed tasks.
+            show_hidden (bool): Whether to include hidden tasks.
+
+        Returns:
+            list: A list of task objects, or an empty list if an error occurred.
+        """
+        try:
+            results = self.service.tasks().list(
+                tasklist=task_list_id,
+                showCompleted=show_completed,
+                showHidden=show_hidden
+            ).execute()
+            return results.get('items', [])
+        except HttpError as err:
+            print(f"An API error occurred while fetching tasks for list ID '{task_list_id}': {err}")
+            return []
+
+# Example usage (for local testing and demonstration purposes)
+# This block will only execute when the script is run directly (e.g., python src/google_tasks_client.py)
+if __name__ == '__main__':
+    # IMPORTANT: To run this example, you need:
+    # 1. `credentials.json` from Google Cloud Console with OAuth 2.0 client ID for a Desktop App.
+    #    Place this file in the same directory as this script, or provide the correct path to GoogleTasksClient.
+    # 2. You will need to authorize the application when it runs for the first time. This will
+    #    create a `token.json` file, storing your OAuth tokens.
+
+    print("--- GoogleTasksClient Demonstration ---")
+    try:
+        # Initialize the client. Ensure 'credentials.json' is available or provide path.
+        client = GoogleTasksClient(credentials_path="credentials.json") 
+        print("GoogleTasksClient initialized successfully.")
+
+        # --- Example Operations ---
+
+        # Optional: Clear all existing task lists (use with extreme caution!)
+        # confirm_clear = input("DANGER: Clear ALL task lists and tasks? (yes/NO): ")
+        # if confirm_clear.lower() == 'yes':
+        #     print("\n--- Clearing all task lists (if any) ---")
+        #     client.clear_all_task_lists_and_tasks()
+        #     print("--- Finished clearing task lists ---")
+        # else:
+        #     print("Skipping clear operation.")
+
+        # 1. Fetch and display existing task lists
+        print("\n--- Fetching Task Lists ---")
+        task_lists = client.get_task_lists()
+        if task_lists:
+            print("Available Task Lists:")
+            for task_list in task_lists:
+                print(f"  - {task_list['title']} (ID: {task_list['id']})")
+        else:
+            print("No task lists found.")
+
+        # 2. Create a new task list
+        print("\n--- Creating a Test Task List ---")
+        list_title = "My Test List from Script"
+        # Check if list already exists to avoid duplicates in demo
+        existing_list = client.get_task_list_by_title(list_title)
+        if existing_list:
+            print(f"Task list '{list_title}' already exists with ID: {existing_list['id']}")
+            test_list = existing_list
+        else:
+            test_list = client.create_task_list(list_title)
+        
+        if test_list:
+            test_list_id = test_list['id']
+            print(f"Using task list '{test_list['title']}' (ID: {test_list_id}) for further tests.")
+
+            # 3. Create tasks in the new list
+            print("\n--- Creating Tasks ---")
+            task1_title = "Buy groceries for the week"
+            task1 = client.create_task(
+                test_list_id, 
+                task1_title, 
+                notes="- Milk\n- Bread\n- Eggs", 
+                due_date_str="2024-07-20" # Example date
+            )
+            if task1: print(f"  Task created: '{task1['title']}' (ID: {task1['id']})")
+            
+            task2_title = "Schedule dentist appointment"
+            task2 = client.create_task(test_list_id, task2_title)
+            if task2: print(f"  Task created: '{task2['title']}' (ID: {task2['id']})")
+
+            # 4. Create a subtask (if task1 was created)
+            if task1:
+                subtask_title = "Get almond milk"
+                subtask1 = client.create_task(
+                    test_list_id, 
+                    subtask_title, 
+                    parent_task_id=task1['id']
+                )
+                if subtask1: print(f"  Subtask created: '{subtask1['title']}' under '{task1['title']}'")
+
+            # 5. Get and display tasks in the test list
+            print(f"\n--- Tasks in '{test_list['title']}' ---")
+            tasks_in_list = client.get_tasks_in_list(test_list_id, show_completed=True, show_hidden=True)
+            if tasks_in_list:
+                for task in tasks_in_list:
+                    print(f"  - {task['title']} (ID: {task['id']}, Status: {task.get('status', 'N/A')})")
+                    if task.get('notes'):
+                        print(f"    Notes: {task['notes']}")
+                    if task.get('due'):
+                        # Format due date for readability if it exists
+                        due_datetime = datetime.datetime.fromisoformat(task['due'].replace('Z', '+00:00'))
+                        print(f"    Due: {due_datetime.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+                    # Google Tasks API list() doesn't inherently nest subtasks.
+                    # One would typically fetch all tasks and reconstruct hierarchy if needed,
+                    # or make separate calls to get children of a specific task if the API supported it directly.
+                    # The `parent` property on a task indicates its parent if it's a subtask.
+            else:
+                print("No tasks found in this list.")
+            
+            # Optional: Delete the test task list for cleanup
+            # confirm_delete_list = input(f"\nDelete the test task list '{test_list['title']}'? (yes/NO): ")
+            # if confirm_delete_list.lower() == 'yes':
+            #     print(f"--- Deleting Test Task List: '{test_list['title']}' ---")
+            #     client.delete_task_list(test_list_id)
+            #     print("--- Test task list deleted ---")
+        else:
+            print(f"Could not create or retrieve '{list_title}' for testing, so further task operations skipped.")
+
+    except FileNotFoundError as e:
+        print(f"Error: {e}. Please ensure 'credentials.json' (or the path you provided) is correct and the file exists.")
+    except HttpError as e:
+        # Detailed error from Google API
+        print(f"An HTTP error occurred: Status {e.resp.status}, Reason: {e.resp.reason}, Content: {e.content.decode()}")
+    except Exception as e:
+        print(f"An unexpected error occurred during the demonstration: {e}")
+        import traceback
+        traceback.print_exc()
+
+    print("\n--- GoogleTasksClient Demonstration Finished ---")

--- a/src/things_reader.py
+++ b/src/things_reader.py
@@ -1,0 +1,300 @@
+import os
+import peewee
+from datetime import datetime
+
+# --- Database Setup ---
+# This global 'db' object will be initialized by the ThingsReader instance
+# with the specific SQLite database path provided at runtime.
+# This allows the models (TMArea, TMTask) to be defined globally but connect
+# to the correct database when ThingsReader is instantiated.
+db = peewee.SqliteDatabase(None)
+
+class BaseModel(peewee.Model):
+    """Base model class for Peewee, specifying the database instance to use."""
+    class Meta:
+        database = db
+
+class TMArea(BaseModel):
+    """Represents an Area in Things 3. Areas are top-level organizational units."""
+    uuid = peewee.CharField(primary_key=True, help_text="Unique identifier for the area.")
+    title = peewee.CharField(null=True, help_text="Title of the area.")
+    trashed = peewee.IntegerField(default=0, help_text="Boolean flag (0 or 1) indicating if the area is trashed.") 
+
+    class Meta:
+        table_name = 'TMArea' # Maps to the TMTask table in Things.db
+
+class TMTask(BaseModel):
+    """
+    Represents a Task, Project, or Heading in Things 3.
+    The 'type' field distinguishes between them.
+    """
+    uuid = peewee.CharField(primary_key=True, help_text="Unique identifier for the item.")
+    type = peewee.IntegerField(choices=[(0, 'Task'), (1, 'Project'), (2, 'Heading')], help_text="Type of the item: 0 for Task, 1 for Project, 2 for Heading.")
+    title = peewee.CharField(null=True, help_text="Title of the item.")
+    notes = peewee.TextField(null=True, help_text="Notes associated with the item.")
+    
+    # Foreign keys for relationships
+    area = peewee.ForeignKeyField(TMArea, backref='tasks', column_name='area', null=True, help_text="Foreign key to the TMArea this item belongs to.")
+    project = peewee.ForeignKeyField('self', backref='tasks_in_project', column_name='project', null=True, help_text="Foreign key to the TMTask (Project) this item belongs to (if it's a task or heading within a project).")
+    heading = peewee.ForeignKeyField('self', backref='tasks_under_heading', column_name='heading', null=True, help_text="Foreign key to the TMTask (Heading) this task belongs to (if it's a task under a heading).")
+    
+    status = peewee.CharField(null=True, help_text="Status of the task, e.g., 'incomplete', 'completed', 'canceled'.")
+    startDate = peewee.DateTimeField(null=True, help_text="Start date of the task (Things 'When' date).") # Original field name from Things
+    dueDate = peewee.DateTimeField(null=True, help_text="Due date of the task (Things 'Deadline').") # Original field name from Things
+    trashed = peewee.IntegerField(default=0, help_text="Boolean flag (0 or 1) indicating if the item is trashed.") # 0 for false, 1 for true
+
+    # Peewee maps these database field names (startDate, dueDate) to model attributes automatically.
+    # These attributes can be used directly in queries and when accessing model instances.
+    # For example, `task_instance.startDate` and `task_instance.dueDate`.
+
+    class Meta:
+        table_name = 'TMTask' # Maps to the TMTask table in Things.db
+
+class ThingsReader:
+    """
+    Reads data from the Things 3 SQLite database.
+    Provides methods to fetch areas, projects, tasks, and headings.
+    """
+    def __init__(self, db_path):
+        """
+        Initializes the ThingsReader and connects to the Things 3 database.
+
+        Args:
+            db_path (str): The file path to the Things 3 SQLite database.
+        
+        Raises:
+            FileNotFoundError: If the database file at db_path does not exist.
+        """
+        self.db_path = db_path
+        if not os.path.exists(self.db_path):
+            raise FileNotFoundError(f"Database file not found: {self.db_path}")
+
+        global db
+        db.init(self.db_path)
+        
+        # Bind models to this specific database instance
+        # This is important if you might connect to multiple databases or in testing
+        self._models = [TMArea, TMTask]
+        db.bind(self._models, bind_refs=False, bind_backrefs=False)
+        
+        db.connect()
+        
+        # Create SQL views for simplified querying of non-trashed Tasks, Projects, and Headings.
+        # These views pre-filter by 'type' and 'trashed' status, making ORM queries cleaner.
+        # Note: Peewee ORM queries in this class primarily use direct model queries with .where() clauses,
+        # which is often more flexible than defining Peewee models for these views.
+        # The views are created for potential direct SQL querying or if model-based view access was desired.
+        db.execute_sql("CREATE VIEW IF NOT EXISTS TaskView AS SELECT * FROM TMTask WHERE type = 0 AND trashed = 0;")
+        db.execute_sql("CREATE VIEW IF NOT EXISTS ProjectView AS SELECT * FROM TMTask WHERE type = 1 AND trashed = 0;")
+        db.execute_sql("CREATE VIEW IF NOT EXISTS HeadingView AS SELECT * FROM TMTask WHERE type = 2 AND trashed = 0;")
+
+    def close(self):
+        """Closes the database connection if it's open."""
+        if not db.is_closed():
+            db.close()
+
+    def get_areas(self):
+        """
+        Retrieves all non-trashed areas from the database.
+        
+        Returns:
+            list: A list of dictionaries, where each dictionary represents an area
+                  with 'uuid' and 'title' keys.
+        """
+        areas_query = TMArea.select(TMArea.uuid, TMArea.title).where(TMArea.trashed == 0)
+        return [
+            {"uuid": area.uuid, "title": area.title}
+            for area in areas_query
+        ]
+
+    def get_projects(self):
+        # Querying TMTask directly with a type filter for projects.
+        # This approach is used instead of querying ProjectView via Peewee ORM models,
+        # as it's generally more straightforward with existing model definitions.
+        projects_query = TMTask.select(TMTask.uuid, TMTask.title, TMTask.notes, TMTask.area) \
+                               .where((TMTask.type == 1) & (TMTask.trashed == 0))
+        return [
+            {
+                "uuid": project.uuid,
+                "title": project.title,
+                "notes": project.notes,
+                "area_uuid": project.area.uuid if project.area else None,
+            }
+            for project in projects_query
+        ]
+
+    def get_tasks(self):
+        tasks_query = TMTask.select(
+                            TMTask.uuid, TMTask.title, TMTask.notes, TMTask.status, 
+                            TMTask.dueDate, TMTask.project, TMTask.area, TMTask.heading # Select relevant fields
+                        ).where((TMTask.type == 0) & (TMTask.trashed == 0)) # Filter for tasks that are not trashed
+        
+        tasks_list = []
+        for task in tasks_query:
+            # Convert Peewee model instance to dictionary for consistent output format
+            tasks_list.append({
+                "uuid": task.uuid,
+                "title": task.title,
+                "notes": task.notes,
+                "status": task.status,
+                "due_date": task.dueDate, # Directly use the dueDate attribute from the model
+                "project_uuid": task.project.uuid if task.project else None,
+                "area_uuid": task.area.uuid if task.area else None,
+                "heading_uuid": task.heading.uuid if task.heading else None,
+            })
+        return tasks_list
+
+    def get_headings_for_project(self, project_uuid):
+        """
+        Retrieves all non-trashed headings associated with a specific project.
+
+        Args:
+            project_uuid (str): The UUID of the project.
+
+        Returns:
+            list: A list of dictionaries, where each dictionary represents a heading
+                  with 'uuid' and 'title' keys.
+        """
+        headings_query = TMTask.select(TMTask.uuid, TMTask.title) \
+                                 .where(
+                                     (TMTask.type == 2) &  # Item is a Heading
+                                     (TMTask.trashed == 0) &  # Heading is not trashed
+                                     (TMTask.project == project_uuid)  # Belongs to the specified project
+                                 )
+        return [
+            {"uuid": heading.uuid, "title": heading.title}
+            for heading in headings_query
+        ]
+
+    def get_tasks_for_project(self, project_uuid):
+        tasks_query = TMTask.select(
+                            TMTask.uuid, TMTask.title, TMTask.notes, TMTask.status, TMTask.dueDate
+                        ).where(
+                            (TMTask.type == 0) &  # Item is a Task
+                            (TMTask.trashed == 0) &  # Task is not trashed
+                            (TMTask.project == project_uuid) &  # Belongs to the specified project
+                            (TMTask.heading.is_null(True))  # Task is not under any heading (directly under project)
+                        )
+        return [
+            {
+                "uuid": task.uuid,
+                "title": task.title,
+                "notes": task.notes,
+                "status": task.status,
+                "due_date": task.dueDate,
+            }
+            for task in tasks_query
+        ]
+        
+    def get_tasks_for_heading(self, heading_uuid):
+        tasks_query = TMTask.select(
+                            TMTask.uuid, TMTask.title, TMTask.notes, TMTask.status, TMTask.dueDate
+                        ).where(
+                            (TMTask.type == 0) &  # Item is a Task
+                            (TMTask.trashed == 0) &  # Task is not trashed
+                            (TMTask.heading == heading_uuid)  # Belongs to the specified heading
+                        )
+        return [
+            {
+                "uuid": task.uuid,
+                "title": task.title,
+                "notes": task.notes,
+                "status": task.status,
+                "due_date": task.dueDate,
+            }
+            for task in tasks_query
+        ]
+
+# Example Usage (primarily for local testing and demonstration)
+# This block will only execute when the script is run directly (e.g., python src/things_reader.py)
+if __name__ == '__main__':
+    # This demonstration requires a 'config.py' file in the project root or adjacent to this script,
+    # which defines THINGS_DB_PATH.
+    # Example 'config.py':
+    # THINGS_DB_PATH = '/Users/yourusername/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/Things Database/main.sqlite'
+
+    print("--- ThingsReader Demonstration ---")
+    try:
+        # Attempt to import configuration to get the database path
+        # This assumes config.py is in a location findable by Python's import system (e.g., project root if running from there)
+        # For more robust path handling, one might adjust sys.path or use environment variables.
+        import config 
+        
+        if not hasattr(config, 'THINGS_DB_PATH') or not config.THINGS_DB_PATH:
+            print("Error: THINGS_DB_PATH is not defined or is empty in your config.py.")
+            print("Please create or update config.py with the path to your Things 3 database.")
+        else:
+            print(f"Attempting to connect to Things DB at: {config.THINGS_DB_PATH}")
+            reader = ThingsReader(db_path=config.THINGS_DB_PATH)
+            
+            print("\n--- Areas ---")
+            areas = reader.get_areas()
+            if areas:
+                for area in areas:
+                    print(f"  - {area['title']} (UUID: {area['uuid']})")
+            else:
+                print("  No areas found.")
+
+            print("\n--- Projects ---")
+            projects = reader.get_projects()
+            if projects:
+                for project in projects:
+                    print(f"  - Project: {project['title']} (UUID: {project['uuid']})")
+                    if project['area_uuid']:
+                         # Find area title for better display (optional, adds queries)
+                        area_info = next((a for a in areas if a['uuid'] == project['area_uuid']), None)
+                        area_name = area_info['title'] if area_info else "N/A"
+                        print(f"    Area: {area_name} (UUID: {project['area_uuid']})")
+                    if project['notes']:
+                        print(f"    Notes: {project['notes'][:50]}...") # Print first 50 chars of notes
+
+                    print("    Headings:")
+                    headings = reader.get_headings_for_project(project['uuid'])
+                    if headings:
+                        for heading in headings:
+                            print(f"      - Heading: {heading['title']} (UUID: {heading['uuid']})")
+                            tasks_under_heading = reader.get_tasks_for_heading(heading['uuid'])
+                            for task in tasks_under_heading:
+                                print(f"        * Task: {task['title']} (Due: {task.get('due_date', 'N/A')})")
+                    else:
+                        print("      No headings in this project.")
+
+                    print("    Tasks (directly under project):")
+                    tasks_in_project = reader.get_tasks_for_project(project['uuid'])
+                    if tasks_in_project:
+                        for task in tasks_in_project:
+                             print(f"      * Task: {task['title']} (Due: {task.get('due_date', 'N/A')})")
+                    else:
+                        print("      No tasks directly under this project.")
+            else:
+                print("  No projects found.")
+
+            print("\n--- All Non-Trashed Tasks (first 5) ---")
+            all_tasks = reader.get_tasks()
+            if all_tasks:
+                for i, task in enumerate(all_tasks[:5]):
+                    print(f"  - Task: {task['title']} (Project UUID: {task.get('project_uuid', 'N/A')}, Area UUID: {task.get('area_uuid', 'N/A')}, Due: {task.get('due_date', 'N/A')})")
+                if len(all_tasks) > 5:
+                    print(f"  ... and {len(all_tasks) - 5} more tasks.")
+            else:
+                print("  No tasks found.")
+            
+            reader.close()
+            print("\nDatabase connection closed.")
+            
+    except FileNotFoundError as e:
+        print(f"Database File Not Found Error: {e}")
+        print("Ensure the THINGS_DB_PATH in your config.py is correct and the file exists.")
+    except ImportError:
+        print("Error: Could not import 'config'.")
+        print("Please ensure a 'config.py' file exists in the correct location (e.g., project root)")
+        print("and contains the THINGS_DB_PATH variable pointing to your Things 3 database.")
+    except peewee.OperationalError as e:
+        print(f"Peewee Operational Error: {e}")
+        print("This might be due to an incorrect database file, a locked database (Things app might be running), or corrupted data.")
+    except Exception as e:
+        print(f"An unexpected error occurred during the demonstration: {e}")
+        import traceback
+        traceback.print_exc()
+
+    print("\n--- ThingsReader Demonstration Finished ---")

--- a/src/things_to_google_tasks.py
+++ b/src/things_to_google_tasks.py
@@ -1,0 +1,434 @@
+import argparse
+import sys
+import os
+import importlib.util # For dynamically loading the config.py file
+from datetime import datetime # Not directly used in this file, but good practice if time elements were needed
+
+# Import custom modules from the 'src' directory
+from things_reader import ThingsReader
+from google_tasks_client import GoogleTasksClient
+
+# --- Configuration Loading ---
+def load_config(config_path):
+    """
+    Dynamically loads configuration settings from a specified Python file.
+    This allows users to store sensitive or environment-specific paths (like DB path)
+    outside the main script.
+
+    Args:
+        config_path (str): The path to the Python configuration file (e.g., "config.py").
+
+    Returns:
+        dict: A dictionary containing the configuration settings found in the file (e.g.,
+              {'THINGS_DB_PATH': '...', 'GOOGLE_API_CREDENTIALS_PATH': '...'}).
+              Returns None if the config file is not found.
+    """
+    if not os.path.exists(config_path):
+        print(f"Error: Config file not found at {config_path}")
+        return None
+    
+    # Create a module specification from the file path.
+    spec = importlib.util.spec_from_file_location("config_module", config_path)
+    if spec is None or spec.loader is None: # Check if spec or loader is None
+        print(f"Error: Could not create module spec for config file at {config_path}")
+        return None
+    config_module = importlib.util.module_from_spec(spec)
+    # Execute the module to make its attributes available.
+    spec.loader.exec_module(config_module)
+    
+    # Extract relevant configuration variables.
+    config = {}
+    if hasattr(config_module, 'THINGS_DB_PATH'):
+        config['THINGS_DB_PATH'] = config_module.THINGS_DB_PATH
+    if hasattr(config_module, 'GOOGLE_API_CREDENTIALS_PATH'):
+        config['GOOGLE_API_CREDENTIALS_PATH'] = config_module.GOOGLE_API_CREDENTIALS_PATH
+    
+    return config
+
+# --- Main Migration Logic ---
+def main():
+    """
+    Main function to orchestrate the migration process.
+    Parses arguments, loads configuration, initializes clients, and performs migration steps.
+    """
+    # --- Argument Parsing ---
+    # Sets up command-line argument parsing for user inputs.
+    parser = argparse.ArgumentParser(
+        description="Migrate tasks and projects from Things 3 to Google Tasks.",
+        formatter_class=argparse.RawTextHelpFormatter # For better help text formatting
+    )
+    parser.add_argument(
+        "--db-path", 
+        help="Path to your Things 3 SQLite database file (main.sqlite).\n"
+             "Example: '/Users/youruser/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/Things Database/main.sqlite'"
+    )
+    parser.add_argument(
+        "--creds-path", 
+        help="Path to your Google API credentials JSON file (e.g., 'credentials.json').\n"
+             "This file is obtained from Google Cloud Console for OAuth 2.0."
+    )
+    parser.add_argument(
+        "--config-file", 
+        help="Path to a Python configuration file (e.g., 'config.py') where\n"
+             "THINGS_DB_PATH and GOOGLE_API_CREDENTIALS_PATH can be defined."
+    )
+    parser.add_argument(
+        "--clean-slate", 
+        action="store_true", 
+        default=False,
+        help="If set, ALL existing Google Task lists and tasks will be deleted\n"
+             "from your Google account before the migration starts. Use with caution!"
+    )
+    args = parser.parse_args()
+
+    # --- Configuration Resolution ---
+    # Determine DB path and credentials path, prioritizing command-line args, then config file.
+    db_path = args.db_path
+    creds_path = args.creds_path
+
+    if args.config_file:
+        print(f"Attempting to load configuration from: {args.config_file}")
+        if not os.path.exists(args.config_file):
+            print(f"Error: Specified config file not found at {args.config_file}")
+            sys.exit(1)
+        config_from_file = load_config(args.config_file)
+        if config_from_file:
+            # If paths are not provided via CLI, use values from config file.
+            db_path = db_path or config_from_file.get('THINGS_DB_PATH')
+            creds_path = creds_path or config_from_file.get('GOOGLE_API_CREDENTIALS_PATH')
+            print("Configuration loaded successfully.")
+        else:
+            # load_config would have printed an error if file exists but loading failed.
+            # If load_config returned None and file exists, it means an issue within load_config.
+            print(f"Failed to load or parse the config file: {args.config_file}")
+            sys.exit(1)
+
+    # --- Path Validation ---
+    # Ensure necessary paths are provided and exist.
+    if not db_path:
+        print("Error: Things 3 database path was not provided. Please use --db-path or set THINGS_DB_PATH in your --config-file.")
+        sys.exit(1)
+    if not creds_path:
+        print("Error: Google API credentials path was not provided. Please use --creds-path or set GOOGLE_API_CREDENTIALS_PATH in your --config-file.")
+        sys.exit(1)
+
+    if not os.path.exists(db_path):
+        print(f"Error: The specified Things 3 database path does not exist: {db_path}")
+        sys.exit(1)
+    if not os.path.exists(creds_path):
+        print(f"Error: The specified Google API credentials file does not exist: {creds_path}")
+        sys.exit(1)
+        
+    print(f"\n--- Configuration Summary ---")
+    print(f"Using Things DB from: {db_path}")
+    print(f"Using Google Credentials from: {creds_path}")
+    print(f"Clean slate mode: {'Enabled' if args.clean_slate else 'Disabled'}")
+    print("-----------------------------\n")
+
+    # --- Initialize API Clients ---
+    # Initialize ThingsReader for database access and GoogleTasksClient for API interaction.
+    try:
+        things_reader = ThingsReader(db_path=db_path)
+        print("ThingsReader initialized successfully.")
+    except FileNotFoundError as e: # Should be caught by os.path.exists, but good for defense
+        print(f"Error initializing ThingsReader (FileNotFound): {e}")
+        sys.exit(1)
+    except Exception as e: # Catch other potential errors from ThingsReader init (e.g., peewee operational error)
+        print(f"An unexpected error occurred while initializing ThingsReader: {e}")
+        sys.exit(1)
+
+    try:
+        google_tasks_client = GoogleTasksClient(credentials_path=creds_path)
+        print("GoogleTasksClient initialized successfully (OAuth flow might run if first time).")
+    except FileNotFoundError as e: # Should be caught by os.path.exists for creds_path
+        print(f"Error initializing GoogleTasksClient (FileNotFound): {e}")
+        sys.exit(1)
+    except Exception as e: # Catch other errors like HttpError during service build or auth issues
+        print(f"An unexpected error occurred while initializing GoogleTasksClient: {e}")
+        sys.exit(1)
+
+    # --- Clean Slate Operation ---
+    # If --clean-slate is enabled, delete all existing Google Tasks data after user confirmation.
+    if args.clean_slate:
+        print("\nWARNING: The --clean-slate option is enabled.")
+        confirm = input("This will delete ALL existing task lists and tasks from your Google Tasks account. This action CANNOT be undone. Are you absolutely sure? [y/N]: ")
+        if confirm.lower() == 'y':
+            print("Proceeding with deleting all Google Tasks data...")
+            try:
+                google_tasks_client.clear_all_task_lists_and_tasks()
+                print("All Google Tasks data has been cleared.")
+            except Exception as e: # Catch potential errors during the clear operation
+                print(f"An error occurred during the clean slate operation: {e}")
+                things_reader.close() # Ensure DB connection is closed
+                sys.exit(1)
+        else:
+            print("Clean slate operation cancelled by the user. Exiting.")
+            things_reader.close() # Ensure DB connection is closed
+            sys.exit(0) # Exit gracefully
+    
+    # --- Migration Process ---
+    print("\n--- Starting Migration: Things 3 to Google Tasks ---")
+    # Cache for Google Task Lists: maps Things Area UUID to Google Task List {'id': ..., 'title': ...}
+    # This avoids repeatedly fetching or creating the same Google Task List.
+    google_task_lists_cache = {} 
+    
+    # Step 1: Migrate Things Areas to Google Task Lists
+    print("\n[Step 1/3] Migrating Areas to Google Task Lists...")
+    try:
+        areas = things_reader.get_areas()
+        if not areas:
+            print("No Areas found in Things.")
+        else:
+            for area in areas:
+                area_title = area['title']
+                area_uuid = area['uuid']
+                print(f"  Processing Area: '{area_title}' (UUID: {area_uuid})")
+                
+                existing_list = google_tasks_client.get_task_list_by_title(area_title)
+                if existing_list:
+                    print(f"    Found existing Google Task List: '{existing_list['title']}' (ID: {existing_list['id']})")
+                    google_task_lists_cache[area_uuid] = {'id': existing_list['id'], 'title': existing_list['title']}
+                else:
+                    print(f"    Creating Google Task List for Area: '{area_title}'...")
+                    new_list = google_tasks_client.create_task_list(title=area_title)
+                    if new_list:
+                        google_task_lists_cache[area_uuid] = {'id': new_list['id'], 'title': new_list['title']}
+                        print(f"    Created Google Task List: '{new_list['title']}' (ID: {new_list['id']})")
+                    else:
+                        print(f"    Failed to create Google Task List for Area: '{area_title}'. Skipping related items.")
+    except Exception as e:
+        print(f"Error during Area migration: {e}")
+        # Decide if to continue or exit
+
+    # Default/Fallback Google Task List for items without an Area or if Area migration failed
+    DEFAULT_LIST_TITLE = "Things Imported Tasks"  # Name for the default list for items without an Area
+    default_google_list_cache = None # Cache for the default list object itself
+
+    def get_or_create_default_list():
+        """
+        Retrieves or creates a default Google Task List for items that don't belong to a specific Area.
+        Uses a local cache (`default_google_list_cache`) to avoid redundant API calls.
+
+        Returns:
+            dict: The default Google Task List object {'id': ..., 'title': ...}, or None if creation fails.
+        """
+        nonlocal default_google_list_cache # Allows modification of the outer scope variable
+        if default_google_list_cache:
+            return default_google_list_cache
+        
+        # Try to find an existing default list
+        existing_default = google_tasks_client.get_task_list_by_title(DEFAULT_LIST_TITLE)
+        if existing_default:
+            print(f"    Found existing default Google Task List: '{existing_default['title']}' (ID: {existing_default['id']})")
+            default_google_list_cache = existing_default
+            return default_google_list_cache
+        
+        # If not found, create it
+        print(f"    Default Google Task List '{DEFAULT_LIST_TITLE}' not found. Creating it...")
+        created_default = google_tasks_client.create_task_list(DEFAULT_LIST_TITLE)
+        if created_default:
+            print(f"    Successfully created default Google Task List: '{created_default['title']}' (ID: {created_default['id']})")
+            default_google_list_cache = created_default
+            return default_google_list_cache
+        else:
+            # This is a significant issue if we can't even create a default list.
+            print(f"    FATAL ERROR: Could not create the default Google Task List '{DEFAULT_LIST_TITLE}'. "
+                  "Tasks without an Area may not be migrated.")
+            return None # Indicates failure
+
+    # Step 2: Migrate Things Projects and their contents (Headings and Tasks)
+    print("\n[Step 2/3] Migrating Projects and their associated Headings & Tasks...")
+    # Set to keep track of Things item UUIDs (tasks, headings) that have been processed as part of a project.
+    # This prevents them from being processed again in the "standalone tasks" step.
+    migrated_project_task_ids = set() 
+
+    try:
+        projects = things_reader.get_projects() # Fetch all non-trashed projects
+        if not projects:
+            print("No Projects found in Things.")
+        else:
+            for project in projects:
+                project_title = project['title']
+                project_uuid = project['uuid']
+                project_notes = project.get('notes', '')
+                area_uuid = project.get('area_uuid')
+                
+                print(f"  Processing Project: '{project_title}' (UUID: {project_uuid})")
+
+                target_list_info = None
+                if area_uuid and area_uuid in google_task_lists_cache:
+                    target_list_info = google_task_lists_cache[area_uuid]
+                else:
+                    print(f"    Project '{project_title}' has no Area or Area not migrated. Using default list.")
+                    target_list_info = get_or_create_default_list()
+                    if not target_list_info:
+                        print(f"    Skipping project '{project_title}' as no suitable Google Task List found/created.")
+                        continue
+                
+                target_list_id = target_list_info['id']
+
+                # Create the main "Project Task" in Google Tasks
+                # Create the main "Project Task" in Google Tasks.
+                # Things Projects are represented as main tasks in Google Tasks.
+                # Their associated Things tasks and headings will become subtasks under this main task.
+                project_main_task_title = f"{project_title}" # Using project title directly
+                print(f"    Creating Google Task for Project '{project_title}' in list '{target_list_info['title']}'...")
+                g_project_task = google_tasks_client.create_task(
+                    task_list_id=target_list_id, 
+                    title=project_main_task_title, 
+                    notes=project_notes # Migrate project notes
+                )
+
+                if not g_project_task:
+                    print(f"    ERROR: Failed to create main Google Task for Project '{project_title}'. Skipping its sub-items.")
+                    continue # Move to the next Things project
+                
+                # Add the Things Project's UUID to the set of processed items.
+                # Although Projects themselves aren't tasks in the same way in the DB, this conceptual marking helps.
+                migrated_project_task_ids.add(project_uuid) 
+                print(f"    Successfully created Google Task for Project: '{g_project_task['title']}' (ID: {g_project_task['id']})")
+
+                # Migrate Headings and Tasks under those Headings for the current Project
+                headings = things_reader.get_headings_for_project(project_uuid=project_uuid) # Get non-trashed headings for this project
+                for heading in headings:
+                    heading_title = heading['title']
+                    heading_uuid = heading['uuid']
+                    print(f"      Processing Heading: '{heading_title}' under Project '{project_title}'")
+                    
+                    # Things Headings are represented as placeholder subtasks under the main project task.
+                    # Tasks that were under this Heading in Things will become subtasks of this placeholder.
+                    g_heading_task_title = f"--- {heading_title} ---" # Visual cue for headings
+                    g_heading_task = google_tasks_client.create_task(
+                        task_list_id=target_list_id,
+                        title=g_heading_task_title,
+                        parent_task_id=g_project_task['id'] # Subtask to the main project task
+                    )
+                    if not g_heading_task:
+                        print(f"      ERROR: Failed to create placeholder Google Task for Heading '{heading_title}'. Skipping its tasks.")
+                        continue # Move to the next Heading
+                    
+                    migrated_project_task_ids.add(heading_uuid) # Mark Things Heading as processed
+                    print(f"      Successfully created placeholder Google Task for Heading: '{g_heading_task['title']}' (ID: {g_heading_task['id']})")
+
+                    # Migrate Tasks that were under this Heading in Things
+                    tasks_under_heading = things_reader.get_tasks_for_heading(heading_uuid=heading_uuid)
+                    for task in tasks_under_heading: # These are non-trashed tasks
+                        task_title = task['title']
+                        task_uuid = task['uuid']
+                        print(f"        Migrating Task (under Heading '{heading_title}'): '{task_title}'")
+                        g_task = google_tasks_client.create_task(
+                            task_list_id=target_list_id,
+                            title=task_title,
+                            notes=task.get('notes', ''),
+                            due_date_str=task.get('due_date'), # `get_tasks_for_heading` provides 'due_date'
+                            parent_task_id=g_heading_task['id'] # Subtask to the heading's placeholder task
+                        )
+                        if g_task:
+                            migrated_project_task_ids.add(task_uuid) # Mark Things Task as processed
+                            print(f"        Successfully created Google Task: '{g_task['title']}' (ID: {g_task['id']})")
+                        else:
+                            print(f"        ERROR: Failed to create Google Task for: '{task_title}'")
+                
+                # Migrate Tasks that are directly under the Project (not under any Heading)
+                project_direct_tasks = things_reader.get_tasks_for_project(project_uuid=project_uuid) # Gets non-trashed, non-heading tasks
+                if project_direct_tasks:
+                    print(f"      Migrating tasks directly under Project '{project_title}'...")
+                for task in project_direct_tasks:
+                    task_title = task['title']
+                    task_uuid = task['uuid']
+                    print(f"        Migrating direct Task: '{task_title}'")
+                    g_task = google_tasks_client.create_task(
+                        task_list_id=target_list_id,
+                        title=task_title,
+                        notes=task.get('notes', ''),
+                        due_date_str=task.get('due_date'),
+                        parent_task_id=g_project_task['id']
+                    )
+                    if g_task:
+                        migrated_project_task_ids.add(task_uuid)
+                        print(f"        Created Task: '{g_task['title']}' (ID: {g_task['id']})")
+                    else:
+                        print(f"        Failed to create task: '{task_title}'")
+
+    except Exception as e:
+        print(f"Error during Project migration: {e}")
+        import traceback
+        traceback.print_exc() # Print full traceback for debugging
+
+
+    # Step 3: Migrate Standalone Tasks
+    # These are tasks from Things that are not part of any project (i.e., project_uuid is None)
+    # and have not already been processed as part of a project's structure.
+    print("\n[Step 3/3] Migrating Standalone Tasks (Tasks not in any Project)...")
+    try:
+        all_things_tasks = things_reader.get_tasks() # Fetches all non-trashed tasks of type 0
+        
+        # Filter for tasks that are truly standalone:
+        # - Not already processed (its UUID is not in migrated_project_task_ids)
+        # - Does not have a 'project_uuid' (according to ThingsReader's get_tasks method output)
+        standalone_tasks_to_migrate = [
+            task for task in all_things_tasks 
+            if task['uuid'] not in migrated_project_task_ids and not task.get('project_uuid')
+        ]
+
+        if not standalone_tasks_to_migrate:
+            print("  No standalone tasks found to migrate.")
+        else:
+            print(f"  Found {len(standalone_tasks_to_migrate)} standalone tasks for migration.")
+            for task in standalone_tasks_to_migrate:
+                task_title = task['title']
+                task_uuid = task['uuid'] # For logging/tracking, though not added to migrated_project_task_ids here
+                area_uuid = task.get('area_uuid')
+
+                print(f"    Processing Standalone Task: '{task_title}' (UUID: {task_uuid})")
+
+                # Determine the target Google Task List for this standalone task
+                target_list_info = None
+                if area_uuid and area_uuid in google_task_lists_cache:
+                    # If task has an Area, and that Area was migrated to a Google Task List
+                    target_list_info = google_task_lists_cache[area_uuid]
+                else:
+                    # If no Area, or Area not found in cache, use the default list
+                    if area_uuid:
+                        print(f"      Task '{task_title}' belongs to Area {area_uuid}, but this Area was not found in cache. Using default list.")
+                    else:
+                        print(f"      Task '{task_title}' has no Area. Using default list.")
+                    target_list_info = get_or_create_default_list()
+                    
+                    if not target_list_info:
+                        print(f"      ERROR: No suitable Google Task List (Area-specific or default) found/created for standalone task '{task_title}'. Skipping.")
+                        continue # Skip this task
+                
+                target_list_id = target_list_info['id']
+                
+                # Create the standalone task in the determined Google Task List
+                g_task = google_tasks_client.create_task(
+                    task_list_id=target_list_id,
+                    title=task_title,
+                    notes=task.get('notes', ''),
+                    due_date_str=task.get('due_date') # `get_tasks` provides 'due_date'
+                )
+                if g_task:
+                    print(f"      Successfully created Standalone Google Task: '{g_task['title']}' in list '{target_list_info['title']}' (ID: {g_task['id']})")
+                else:
+                    print(f"      ERROR: Failed to create standalone Google Task for: '{task_title}'")
+    except Exception as e:
+        print(f"An error occurred during Standalone Task migration: {e}")
+        import traceback
+        traceback.print_exc() # Print full traceback
+
+    # --- Migration Cleanup ---
+    print("\n--- Finalizing Migration ---")
+    try:
+        things_reader.close()
+        print("Things 3 database connection closed successfully.")
+    except Exception as e:
+        print(f"Error closing Things 3 database connection: {e}")
+
+    print("\nMigration process completed.")
+    print("Please check your Google Tasks account to see the migrated items.")
+
+if __name__ == "__main__":
+    # This ensures that main() is called only when the script is executed directly,
+    # not when it's imported as a module.
+    main()

--- a/tests/test_google_tasks_client.py
+++ b/tests/test_google_tasks_client.py
@@ -1,0 +1,285 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open, call
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+from google_tasks_client import GoogleTasksClient, TOKEN_FILE, SCOPES
+from google.oauth2.credentials import Credentials
+from google.auth.transport.requests import Request # For token refresh
+# Assuming HttpError is from googleapiclient.errors
+from googleapiclient.errors import HttpError 
+from datetime import datetime
+
+class TestGoogleTasksClient(unittest.TestCase):
+
+    @patch('google.oauth2.credentials.Credentials.from_authorized_user_file')
+    @patch('google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file')
+    @patch('googleapiclient.discovery.build')
+    @patch('os.path.exists')
+    @patch('builtins.open', new_callable=mock_open)
+    def setUp(self, mock_file_open_builtin, mock_os_exists, mock_build, mock_flow_from_secrets, mock_creds_from_file):
+        # Store mocks for later use if needed
+        self.mock_file_open_builtin = mock_file_open_builtin
+        self.mock_os_exists = mock_os_exists
+        self.mock_build = mock_build
+        self.mock_flow_from_secrets = mock_flow_from_secrets
+        self.mock_creds_from_file = mock_creds_from_file
+        
+        # Setup mock service
+        self.mock_service = MagicMock()
+        self.mock_build.return_value = self.mock_service
+        
+        # Mock credentials flow
+        self.mock_creds = MagicMock(spec=Credentials)
+        self.mock_creds.valid = True # Assume valid initially
+        self.mock_creds.expired = False
+        self.mock_creds.refresh_token = None # Default to no refresh token initially
+
+        # Scenario 1: token.json exists and is valid
+        self.mock_os_exists.side_effect = lambda path: path == TOKEN_FILE or path == 'dummy_creds.json'
+        self.mock_creds_from_file.return_value = self.mock_creds
+        
+        self.client = GoogleTasksClient(credentials_path='dummy_creds.json')
+
+    def _reset_auth_mocks(self):
+        self.mock_os_exists.reset_mock()
+        self.mock_creds_from_file.reset_mock()
+        self.mock_flow_from_secrets.reset_mock()
+        self.mock_build.reset_mock()
+        self.mock_file_open_builtin.reset_mock()
+        self.mock_service.reset_mock()
+
+        # Re-patch the mock_creds object as it might have been modified by tests (e.g. .valid)
+        self.mock_creds = MagicMock(spec=Credentials)
+        self.mock_creds.valid = True 
+        self.mock_creds.expired = False
+        self.mock_creds.refresh_token = None
+        self.mock_creds_from_file.return_value = self.mock_creds # For from_authorized_user_file path
+        
+        # For from_client_secrets_file path
+        mock_flow_instance = self.mock_flow_from_secrets.return_value
+        mock_flow_instance.run_local_server.return_value = self.mock_creds
+
+
+    def test_authentication_token_exists_valid(self):
+        self._reset_auth_mocks()
+        self.mock_os_exists.side_effect = lambda path: path == TOKEN_FILE or path == 'dummy_creds.json'
+        self.mock_creds_from_file.return_value = self.mock_creds
+        self.mock_creds.valid = True
+
+        client = GoogleTasksClient(credentials_path='dummy_creds.json')
+        
+        self.mock_creds_from_file.assert_called_once_with(TOKEN_FILE, SCOPES)
+        self.mock_flow_from_secrets.assert_not_called() # Should not run OAuth flow
+        self.mock_build.assert_called_once_with('tasks', 'v1', credentials=self.mock_creds)
+        self.assertIsNotNone(client.service)
+
+    @patch('google.oauth2.credentials.Credentials.refresh')
+    def test_authentication_token_exists_expired_refreshable(self, mock_refresh):
+        self._reset_auth_mocks()
+        self.mock_os_exists.side_effect = lambda path: path == TOKEN_FILE or path == 'dummy_creds.json'
+        self.mock_creds_from_file.return_value = self.mock_creds
+        self.mock_creds.valid = False # Token is not valid
+        self.mock_creds.expired = True # Token is expired
+        self.mock_creds.refresh_token = "fake_refresh_token" # Token has a refresh token
+
+        client = GoogleTasksClient(credentials_path='dummy_creds.json')
+
+        self.mock_creds_from_file.assert_called_once_with(TOKEN_FILE, SCOPES)
+        mock_refresh.assert_called_once_with(Request()) # Request() should be from google.auth.transport.requests
+        self.mock_file_open_builtin.assert_called_with(TOKEN_FILE, 'w') # Should save refreshed token
+        self.mock_flow_from_secrets.assert_not_called()
+        self.mock_build.assert_called_once_with('tasks', 'v1', credentials=self.mock_creds)
+        self.assertIsNotNone(client.service)
+
+    def test_authentication_no_token_run_flow(self):
+        self._reset_auth_mocks()
+        # Simulate no token.json, but credentials.json exists
+        self.mock_os_exists.side_effect = lambda path: path == 'dummy_creds.json' 
+        self.mock_creds_from_file.return_value = None # No token loaded
+
+        mock_flow_instance = self.mock_flow_from_secrets.return_value
+        mock_flow_instance.run_local_server.return_value = self.mock_creds # OAuth flow returns new creds
+
+        client = GoogleTasksClient(credentials_path='dummy_creds.json')
+
+        self.mock_creds_from_file.assert_called_once_with(TOKEN_FILE, SCOPES) # Attempted to load token
+        self.mock_flow_from_secrets.assert_called_once_with('dummy_creds.json', SCOPES)
+        mock_flow_instance.run_local_server.assert_called_once_with(port=0)
+        self.mock_file_open_builtin.assert_called_with(TOKEN_FILE, 'w') # Save new token
+        self.mock_build.assert_called_once_with('tasks', 'v1', credentials=self.mock_creds)
+
+    def test_authentication_credentials_file_not_found(self):
+        self._reset_auth_mocks()
+        self.mock_os_exists.return_value = False # Simulate no token.json AND no credentials.json
+        self.mock_creds_from_file.return_value = None
+
+        with self.assertRaisesRegex(FileNotFoundError, "Credentials file not found at non_existent_creds.json"):
+            GoogleTasksClient(credentials_path='non_existent_creds.json')
+        
+        self.mock_flow_from_secrets.assert_not_called()
+
+
+    def test_get_task_lists(self):
+        self.mock_service.tasklists().list().execute.return_value = {'items': [{'id': 'list1', 'title': 'List One'}]}
+        lists = self.client.get_task_lists()
+        self.assertEqual(len(lists), 1)
+        self.assertEqual(lists[0]['title'], 'List One')
+        self.mock_service.tasklists().list().execute.assert_called_once()
+
+    def test_get_task_lists_api_error(self):
+        self.mock_service.tasklists().list().execute.side_effect = HttpError(MagicMock(status=500), b"Server Error")
+        with patch('builtins.print') as mock_print:
+            lists = self.client.get_task_lists()
+            self.assertEqual(lists, [])
+            mock_print.assert_any_call(unittest.mock.ANY) # Check if print was called with error message
+
+    def test_get_task_list_by_title_found(self):
+        self.client.get_task_lists = MagicMock(return_value=[
+            {'id': 'list1', 'title': 'Work'},
+            {'id': 'list2', 'title': 'Personal'}
+        ])
+        found_list = self.client.get_task_list_by_title('Personal')
+        self.assertEqual(found_list['id'], 'list2')
+
+    def test_get_task_list_by_title_not_found(self):
+        self.client.get_task_lists = MagicMock(return_value=[
+            {'id': 'list1', 'title': 'Work'}
+        ])
+        found_list = self.client.get_task_list_by_title('Shopping')
+        self.assertIsNone(found_list)
+
+    def test_create_task_list(self):
+        self.mock_service.tasklists().insert(body={'title': 'New List'}).execute.return_value = {'id': 'list2', 'title': 'New List'}
+        new_list = self.client.create_task_list(title='New List')
+        self.assertEqual(new_list['title'], 'New List')
+        self.mock_service.tasklists().insert.assert_called_with(body={'title': 'New List'})
+
+    def test_create_task_list_api_error(self):
+        self.mock_service.tasklists().insert(body={'title': 'New List'}).execute.side_effect = HttpError(MagicMock(status=403), b"Forbidden")
+        with patch('builtins.print') as mock_print:
+            new_list = self.client.create_task_list(title='New List')
+            self.assertIsNone(new_list)
+            mock_print.assert_any_call(unittest.mock.ANY)
+
+    def test_delete_task_list(self):
+        self.mock_service.tasklists().delete(tasklist='list1').execute.return_value = None # Delete usually returns empty
+        with patch('builtins.print') as mock_print:
+            self.client.delete_task_list(task_list_id='list1')
+            mock_print.assert_called_with("Task list ID 'list1' deleted successfully.")
+
+    def test_delete_task_list_not_found(self):
+        # Simulate HttpError with a response object that has a 'status' attribute
+        mock_resp = MagicMock()
+        mock_resp.status = 404
+        self.mock_service.tasklists().delete(tasklist='list1').execute.side_effect = HttpError(mock_resp, b"Not Found")
+        with patch('builtins.print') as mock_print:
+            self.client.delete_task_list(task_list_id='list1')
+            mock_print.assert_called_with("Task list ID 'list1' not found. Could not delete.")
+            
+    def test_delete_task_list_other_api_error(self):
+        mock_resp = MagicMock()
+        mock_resp.status = 500
+        self.mock_service.tasklists().delete(tasklist='list1').execute.side_effect = HttpError(mock_resp, b"Server Error")
+        with patch('builtins.print') as mock_print:
+            self.client.delete_task_list(task_list_id='list1')
+            self.assertTrue("An API error occurred while deleting task list ID 'list1'" in mock_print.call_args[0][0])
+
+
+    def test_clear_all_task_lists_and_tasks(self):
+        # Mock get_task_lists to return a list of lists to delete
+        self.client.get_task_lists = MagicMock(return_value=[{'id': 'list1', 'title': 'List One'}, {'id': 'list2', 'title': 'List Two'}])
+        # Mock delete_task_list
+        self.client.delete_task_list = MagicMock() # This will be called by the method under test
+
+        self.client.clear_all_task_lists_and_tasks()
+        
+        self.assertEqual(self.client.delete_task_list.call_count, 2)
+        self.client.delete_task_list.assert_any_call('list1')
+        self.client.delete_task_list.assert_any_call('list2')
+
+    def test_clear_all_task_lists_no_lists(self):
+        self.client.get_task_lists = MagicMock(return_value=[])
+        self.client.delete_task_list = MagicMock()
+        with patch('builtins.print') as mock_print:
+            self.client.clear_all_task_lists_and_tasks()
+            self.client.delete_task_list.assert_not_called()
+            mock_print.assert_any_call("No task lists found to delete.")
+
+
+    def test_create_task_simple(self):
+        task_body = {'title': 'Test Task'} 
+        self.mock_service.tasks().insert(tasklist='list1', body=task_body, parent=None).execute.return_value = {'id': 'task1', 'title': 'Test Task'}
+        
+        task = self.client.create_task(task_list_id='list1', title='Test Task')
+        self.assertEqual(task['title'], 'Test Task')
+        self.mock_service.tasks().insert.assert_called_with(tasklist='list1', body=task_body, parent=None)
+
+    def test_create_task_with_details(self):
+        due_date_str = "2024-03-10"
+        # Expected RFC3339 format for Google Tasks API
+        expected_due_api_format = datetime.strptime(due_date_str, '%Y-%m-%d').isoformat() + 'Z'
+        
+        task_body = {'title': 'Test Task', 'notes': 'Some notes', 'due': expected_due_api_format}
+        self.mock_service.tasks().insert(tasklist='list1', body=task_body, parent=None).execute.return_value = {'id': 'task1', **task_body}
+        
+        task = self.client.create_task(task_list_id='list1', title='Test Task', notes='Some notes', due_date_str=due_date_str)
+        self.assertEqual(task['title'], 'Test Task')
+        self.assertEqual(task['notes'], 'Some notes')
+        self.assertEqual(task['due'], expected_due_api_format)
+        self.mock_service.tasks().insert.assert_called_with(tasklist='list1', body=task_body, parent=None)
+
+    def test_create_task_with_invalid_due_date(self):
+        task_body = {'title': 'Test Task'} # Due date should not be included if invalid
+        self.mock_service.tasks().insert(tasklist='list1', body=task_body, parent=None).execute.return_value = {'id': 'task1', **task_body}
+        
+        with patch('builtins.print') as mock_print:
+            task = self.client.create_task(task_list_id='list1', title='Test Task', due_date_str="invalid-date")
+            self.assertEqual(task['title'], 'Test Task')
+            self.assertNotIn('due', task) # Due date should not be set
+            mock_print.assert_any_call("Invalid due date format: invalid-date. Please use YYYY-MM-DD.")
+        self.mock_service.tasks().insert.assert_called_with(tasklist='list1', body=task_body, parent=None)
+
+
+    def test_create_sub_task(self):
+        sub_task_body = {'title': 'Sub Task'}
+        self.mock_service.tasks().insert(tasklist='list1', body=sub_task_body, parent='parent_task_id').execute.return_value = {'id': 'subtask1', 'title': 'Sub Task'}
+
+        sub_task = self.client.create_task(task_list_id='list1', title='Sub Task', parent_task_id='parent_task_id')
+        self.assertEqual(sub_task['title'], 'Sub Task')
+        self.mock_service.tasks().insert.assert_called_with(tasklist='list1', body=sub_task_body, parent='parent_task_id')
+
+    def test_create_task_api_error(self):
+        self.mock_service.tasks().insert(tasklist='list1', body={'title': 'Test Task'}, parent=None).execute.side_effect = HttpError(MagicMock(status=500), b"Server Error")
+        with patch('builtins.print') as mock_print:
+            task = self.client.create_task(task_list_id='list1', title='Test Task')
+            self.assertIsNone(task)
+            mock_print.assert_any_call(unittest.mock.ANY)
+
+
+    def test_get_tasks_in_list(self):
+        self.mock_service.tasks().list(tasklist='list1', showCompleted=False, showHidden=False).execute.return_value = {
+            'items': [{'id': 'task1', 'title': 'Active Task'}]
+        }
+        tasks = self.client.get_tasks_in_list('list1')
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]['title'], 'Active Task')
+
+    def test_get_tasks_in_list_show_completed_hidden(self):
+        self.mock_service.tasks().list(tasklist='list1', showCompleted=True, showHidden=True).execute.return_value = {
+            'items': [{'id': 'task1', 'title': 'Task A'}, {'id': 'task2', 'title': 'Task B'}]
+        }
+        tasks = self.client.get_tasks_in_list('list1', show_completed=True, show_hidden=True)
+        self.assertEqual(len(tasks), 2)
+        self.mock_service.tasks().list.assert_called_with(tasklist='list1', showCompleted=True, showHidden=True)
+
+    def test_get_tasks_in_list_api_error(self):
+        self.mock_service.tasks().list(tasklist='list1', showCompleted=False, showHidden=False).execute.side_effect = HttpError(MagicMock(status=500), b"Server Error")
+        with patch('builtins.print') as mock_print:
+            tasks = self.client.get_tasks_in_list('list1')
+            self.assertEqual(tasks, [])
+            mock_print.assert_any_call(unittest.mock.ANY)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_migration_logic.py
+++ b/tests/test_migration_logic.py
@@ -1,0 +1,282 @@
+import unittest
+from unittest.mock import patch, MagicMock, call, ANY
+import argparse
+import os
+import sys
+
+# Add 'src' to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+# Import main function from the script.
+from things_to_google_tasks import main as run_migration_main, load_config
+
+class TestMigrationLogic(unittest.TestCase):
+
+    # Helper to create a Namespace object from a dict
+    def _make_namespace(self, **kwargs):
+        return argparse.Namespace(**kwargs)
+
+    @patch('src.things_to_google_tasks.ThingsReader')
+    @patch('src.things_to_google_tasks.GoogleTasksClient')
+    @patch('builtins.input', return_value='y') # Auto-confirm 'yes' for clean slate
+    @patch('os.path.exists') # Mock os.path.exists globally for this test
+    @patch('src.things_to_google_tasks.load_config') # Mock config loading
+    def test_full_migration_flow_clean_slate(self, mock_load_config, mock_os_exists, mock_input, MockGoogleTasksClient, MockThingsReader):
+        # --- Setup Mocks ---
+        mock_things_reader = MockThingsReader.return_value
+        mock_google_tasks_client = MockGoogleTasksClient.return_value
+
+        # os.path.exists should return True for db_path and creds_path, False for config_file if not used
+        def os_exists_side_effect(path):
+            if path in ['dummy_db.sqlite', 'dummy_creds.json']:
+                return True
+            return False # Default for other paths like config file if not specified
+        mock_os_exists.side_effect = os_exists_side_effect
+        
+        # Mock config loading to return empty if not used, or specific values if config_file is tested
+        mock_load_config.return_value = {}
+
+
+        # --- Mock Data from ThingsReader ---
+        mock_things_reader.get_areas.return_value = [{'uuid': 'area1', 'title': 'Work Area From Things'}]
+        mock_things_reader.get_projects.return_value = [
+            {'uuid': 'proj1', 'title': 'Office Reno', 'area_uuid': 'area1', 'notes': 'Project notes', 'status': 'incomplete', 'dueDate': None}
+        ]
+        mock_things_reader.get_headings_for_project.return_value = [
+            {'uuid': 'head1', 'title': 'Planning'}
+        ]
+        mock_things_reader.get_tasks_for_heading.return_value = [ # Tasks under 'Planning' heading
+            {'uuid': 'taskH1', 'title': 'Call contractor', 'notes': 'Get quotes', 'status': 'incomplete', 'due_date': '2024-08-15'}
+        ]
+        mock_things_reader.get_tasks_for_project.return_value = [ # Tasks directly under 'Office Reno' project
+            {'uuid': 'taskP1', 'title': 'Order paint', 'notes': 'Blue color', 'status': 'incomplete', 'due_date': None}
+        ]
+        # For standalone tasks. Ensure no overlap with project tasks for clarity.
+        mock_things_reader.get_tasks.return_value = [
+            {'uuid': 'taskS1', 'title': 'Buy milk', 'area_uuid': None, 'project_uuid': None, 'heading_uuid': None, 'notes': '', 'status': 'incomplete', 'due_date': None},
+            # This task is part of a project, get_tasks() in things_reader would return it,
+            # but the migration script filters it out from standalone processing
+            # because it has a project_uuid or its uuid is in migrated_project_task_ids.
+            # To test standalone, ensure it's truly standalone.
+            {'uuid': 'taskH1', 'title': 'Call contractor', 'area_uuid': 'area1', 'project_uuid': 'proj1', 'heading_uuid': 'head1', 'notes': 'Get quotes', 'status': 'incomplete', 'due_date': '2024-08-15'},
+            {'uuid': 'taskP1', 'title': 'Order paint', 'area_uuid': 'area1', 'project_uuid': 'proj1', 'heading_uuid': None, 'notes': 'Blue color', 'status': 'incomplete', 'due_date': None}
+        ]
+
+
+        # --- Mock GoogleTasksClient Behavior ---
+        # Simulate no existing lists initially for clean_slate
+        mock_google_tasks_client.get_task_list_by_title.return_value = None 
+        
+        # Return values for created lists
+        mock_work_list = {'id': 'glist_work', 'title': 'Work Area From Things'}
+        mock_default_list = {'id': 'glist_default', 'title': 'Things Imported Tasks'}
+        
+        def create_task_list_side_effect(title):
+            if title == 'Work Area From Things':
+                return mock_work_list
+            elif title == 'Things Imported Tasks':
+                return mock_default_list
+            return {'id': f'glist_{title.lower()}', 'title': title}
+        mock_google_tasks_client.create_task_list.side_effect = create_task_list_side_effect
+        
+        # Return values for created tasks (main project task, heading, tasks under heading, tasks under project, standalone)
+        g_project_main_task = {'id': 'g_proj1_main', 'title': 'Office Reno'}
+        g_heading_task = {'id': 'g_head1_placeholder', 'title': '--- Planning ---'}
+        g_task_under_heading = {'id': 'g_taskH1', 'title': 'Call contractor'}
+        g_task_under_project = {'id': 'g_taskP1', 'title': 'Order paint'}
+        g_standalone_task = {'id': 'g_taskS1', 'title': 'Buy milk'}
+
+        create_task_calls = []
+        def create_task_side_effect(task_list_id, title, notes=None, due_date_str=None, parent_task_id=None):
+            create_task_calls.append(call(task_list_id=task_list_id, title=title, notes=notes, due_date_str=due_date_str, parent_task_id=parent_task_id))
+            if title == 'Office Reno': return g_project_main_task
+            if title == '--- Planning ---': return g_heading_task
+            if title == 'Call contractor': return g_task_under_heading
+            if title == 'Order paint': return g_task_under_project
+            if title == 'Buy milk': return g_standalone_task
+            return {'id': f'g_{title.replace(" ", "").lower()}', 'title': title} # Generic fallback
+        mock_google_tasks_client.create_task.side_effect = create_task_side_effect
+
+
+        # --- Simulate running the main script ---
+        test_args = self._make_namespace(
+            db_path='dummy_db.sqlite', 
+            creds_path='dummy_creds.json', 
+            clean_slate=True,
+            config_file=None # Explicitly not using a config file for this test run
+        )
+        with patch('argparse.ArgumentParser.parse_args', return_value=test_args):
+            run_migration_main()
+
+        # --- Assertions ---
+        mock_input.assert_called_once_with("Are you sure you want to delete ALL Google Tasks data? This cannot be undone. [y/N]: ")
+        mock_google_tasks_client.clear_all_task_lists_and_tasks.assert_called_once()
+
+        # Area migration
+        mock_google_tasks_client.create_task_list.assert_any_call(title='Work Area From Things')
+        
+        # Project migration (Office Reno)
+        # 1. Main project task
+        expected_project_call = call(
+            task_list_id=mock_work_list['id'], 
+            title='Office Reno', 
+            notes='Project notes', 
+            due_date_str=None, # from mocked project data
+            parent_task_id=None
+        )
+        self.assertIn(expected_project_call, create_task_calls)
+        
+        # 2. Heading under project
+        expected_heading_call = call(
+            task_list_id=mock_work_list['id'], 
+            title='--- Planning ---', 
+            notes=None, # Headings typically don't have notes in this migration
+            due_date_str=None,
+            parent_task_id=g_project_main_task['id']
+        )
+        self.assertIn(expected_heading_call, create_task_calls)
+
+        # 3. Task under heading
+        expected_task_under_heading_call = call(
+            task_list_id=mock_work_list['id'], 
+            title='Call contractor', 
+            notes='Get quotes', 
+            due_date_str='2024-08-15',
+            parent_task_id=g_heading_task['id']
+        )
+        self.assertIn(expected_task_under_heading_call, create_task_calls)
+
+        # 4. Task directly under project
+        expected_task_under_project_call = call(
+            task_list_id=mock_work_list['id'], 
+            title='Order paint', 
+            notes='Blue color', 
+            due_date_str=None,
+            parent_task_id=g_project_main_task['id']
+        )
+        self.assertIn(expected_task_under_project_call, create_task_calls)
+        
+        # Standalone task migration ('Buy milk')
+        # It should go to the default list because it has no area.
+        mock_google_tasks_client.create_task_list.assert_any_call(title='Things Imported Tasks')
+        expected_standalone_task_call = call(
+            task_list_id=mock_default_list['id'], 
+            title='Buy milk', 
+            notes='', 
+            due_date_str=None,
+            parent_task_id=None
+        )
+        self.assertIn(expected_standalone_task_call, create_task_calls)
+
+        # Verify ThingsReader close was called
+        mock_things_reader.close.assert_called_once()
+
+
+    @patch('src.things_to_google_tasks.ThingsReader')
+    @patch('src.things_to_google_tasks.GoogleTasksClient')
+    @patch('os.path.exists')
+    @patch('src.things_to_google_tasks.load_config')
+    def test_migration_no_clean_slate_uses_existing_lists(self, mock_load_config, mock_os_exists, MockGoogleTasksClient, MockThingsReader):
+        mock_things_reader = MockThingsReader.return_value
+        mock_google_tasks_client = MockGoogleTasksClient.return_value
+        mock_os_exists.return_value = True # db and creds paths exist
+        mock_load_config.return_value = {}
+
+        # ThingsReader data
+        mock_things_reader.get_areas.return_value = [{'uuid': 'area1', 'title': 'Personal'}]
+        mock_things_reader.get_projects.return_value = [] # No projects for simplicity
+        mock_things_reader.get_tasks.return_value = [
+             {'uuid': 'taskS1', 'title': 'Gym session', 'area_uuid': 'area1', 'project_uuid': None, 'heading_uuid': None, 'notes': '', 'status': 'incomplete', 'due_date': None}
+        ]
+
+        # GoogleTasksClient - simulate 'Personal' list already exists
+        existing_personal_list = {'id': 'glist_personal_existing', 'title': 'Personal'}
+        mock_google_tasks_client.get_task_list_by_title.return_value = existing_personal_list
+        
+        # Task creation mock
+        mock_google_tasks_client.create_task.return_value = {'id': 'gtask_gym', 'title': 'Gym session'}
+
+        test_args = self._make_namespace(db_path='d.db', creds_path='c.json', clean_slate=False, config_file=None)
+        with patch('argparse.ArgumentParser.parse_args', return_value=test_args):
+            run_migration_main()
+
+        mock_google_tasks_client.clear_all_task_lists_and_tasks.assert_not_called()
+        mock_google_tasks_client.create_task_list.assert_not_called() # Should use existing
+        mock_google_tasks_client.get_task_list_by_title.assert_called_with('Personal')
+        
+        mock_google_tasks_client.create_task.assert_called_once_with(
+            task_list_id=existing_personal_list['id'],
+            title='Gym session',
+            notes='',
+            due_date_str=None, # from mock task data
+            parent_task_id=None
+        )
+        mock_things_reader.close.assert_called_once()
+
+
+    @patch('src.things_to_google_tasks.ThingsReader')
+    @patch('src.things_to_google_tasks.GoogleTasksClient')
+    @patch('builtins.input', return_value='n') # User says NO to clean slate
+    @patch('os.path.exists', return_value=True)
+    @patch('src.things_to_google_tasks.load_config')
+    def test_clean_slate_cancelled_by_user(self, mock_load_config, mock_os_exists, mock_input, MockGoogleTasksClient, MockThingsReader):
+        mock_load_config.return_value = {}
+        mock_google_tasks_client = MockGoogleTasksClient.return_value
+        mock_things_reader = MockThingsReader.return_value
+
+        test_args = self._make_namespace(db_path='d.db', creds_path='c.json', clean_slate=True, config_file=None)
+        with patch('argparse.ArgumentParser.parse_args', return_value=test_args), \
+             patch('sys.exit') as mock_sys_exit: # Patch sys.exit to prevent test runner from exiting
+            run_migration_main()
+
+        mock_input.assert_called_once()
+        mock_google_tasks_client.clear_all_task_lists_and_tasks.assert_not_called()
+        mock_sys_exit.assert_called_once_with(0) # Should exit gracefully
+        mock_things_reader.close.assert_called_once() # Ensure cleanup happens even if exiting early
+
+
+    @patch('src.things_to_google_tasks.ThingsReader')
+    @patch('src.things_to_google_tasks.GoogleTasksClient')
+    @patch('os.path.exists')
+    @patch('src.things_to_google_tasks.load_config') # Patch load_config
+    def test_config_file_usage(self, mock_load_config, mock_os_exists, MockGoogleTasksClient, MockThingsReader):
+        # Simulate config file providing paths
+        mock_load_config.return_value = {
+            'THINGS_DB_PATH': 'config_db.sqlite',
+            'GOOGLE_API_CREDENTIALS_PATH': 'config_creds.json'
+        }
+        # os.path.exists needs to be true for paths from config
+        def os_exists_side_effect(path):
+            return path in ['config_db.sqlite', 'config_creds.json', 'my_config.py']
+        mock_os_exists.side_effect = os_exists_side_effect
+
+        # Mock clients and their methods to prevent actual operations
+        MockThingsReader.return_value.get_areas.return_value = []
+        MockThingsReader.return_value.get_projects.return_value = []
+        MockThingsReader.return_value.get_tasks.return_value = []
+        MockGoogleTasksClient.return_value.get_task_list_by_title.return_value = None
+
+        test_args = self._make_namespace(
+            db_path=None, # No direct CLI path for db
+            creds_path=None, # No direct CLI path for creds
+            clean_slate=False,
+            config_file='my_config.py'
+        )
+        with patch('argparse.ArgumentParser.parse_args', return_value=test_args):
+            run_migration_main()
+        
+        mock_load_config.assert_called_once_with('my_config.py')
+        # Verify ThingsReader and GoogleTasksClient were initialized with paths from config
+        MockThingsReader.assert_called_once_with(db_path='config_db.sqlite')
+        MockGoogleTasksClient.assert_called_once_with(credentials_path='config_creds.json')
+
+    # TODO: Add tests for:
+    # - Projects/Tasks with no Area (should go to default "Things Imported Tasks" list)
+    # - Error handling if ThingsReader fails to initialize
+    # - Error handling if GoogleTasksClient fails to initialize
+    # - Error handling during API calls (e.g., create_task_list fails, create_task fails)
+    # - Path validation errors (db_path or creds_path not found)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_things_reader.py
+++ b/tests/test_things_reader.py
@@ -1,0 +1,211 @@
+import unittest
+from unittest.mock import patch, MagicMock, PropertyMock
+import peewee
+import os
+# Add 'src' to sys.path to allow importing 'things_reader'
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+from things_reader import ThingsReader, TMArea, TMTask # Assuming these are importable
+
+# Define a dummy database for in-memory testing
+test_db = peewee.SqliteDatabase(':memory:')
+
+class TestThingsReader(unittest.TestCase):
+
+    def setUp(self):
+        # Patch the database path that ThingsReader will use
+        self.mock_db_path = ":memory:" 
+
+        # Mock peewee.SqliteDatabase to always return our test_db
+        # We are not mocking the class itself, but the instance creation within things_reader.py
+        # The global 'db' object in things_reader will be initialized with this test_db
+        self.patcher_sqlite_db_init = patch('src.things_reader.db.init', return_value=None)
+        self.mock_db_init = self.patcher_sqlite_db_init.start()
+        
+        # Configure the global 'db' object in things_reader to use our test_db
+        from things_reader import db as things_reader_db
+        things_reader_db.initialize(test_db) # Use initialize to set the db for models
+
+        # Bind models to the test database for the duration of the test
+        # This ensures that any operations on TMArea, TMTask use test_db
+        self._original_area_db = TMArea._meta.database
+        self._original_task_db = TMTask._meta.database
+        TMArea._meta.database = test_db
+        TMTask._meta.database = test_db
+        
+        test_db.connect(reuse_if_open=True)
+        test_db.create_tables([TMArea, TMTask], safe=True)
+
+        # Create views as ThingsReader would
+        try:
+            test_db.execute_sql("CREATE VIEW IF NOT EXISTS TaskView AS SELECT * FROM TMTask WHERE type = 0 AND trashed = 0;")
+            test_db.execute_sql("CREATE VIEW IF NOT EXISTS ProjectView AS SELECT * FROM TMTask WHERE type = 1 AND trashed = 0;")
+            test_db.execute_sql("CREATE VIEW IF NOT EXISTS HeadingView AS SELECT * FROM TMTask WHERE type = 2 AND trashed = 0;")
+        except peewee.OperationalError as e:
+            # print(f"setUp view creation error: {e}") # a T&L test comment
+            pass 
+
+        # Now, initialize ThingsReader. It should use the already patched and configured db.
+        self.reader = ThingsReader(db_path=self.mock_db_path)
+        # The reader's __init__ will call db.connect(), which is fine for an in-memory db.
+
+
+    def tearDown(self):
+        self.patcher_sqlite_db_init.stop()
+        
+        test_db.drop_tables([TMArea, TMTask], safe=True)
+        try:
+            test_db.execute_sql("DROP VIEW IF EXISTS TaskView;")
+            test_db.execute_sql("DROP VIEW IF EXISTS ProjectView;")
+            test_db.execute_sql("DROP VIEW IF EXISTS HeadingView;")
+        except peewee.OperationalError as e:
+            # print(f"tearDown view drop error: {e}") # a T&L test comment
+            pass
+        
+        test_db.close()
+        
+        # Restore original database meta for models to avoid interference between tests or with other parts of an application
+        TMArea._meta.database = self._original_area_db
+        TMTask._meta.database = self._original_task_db
+
+
+    def test_get_areas(self):
+        TMArea.create(uuid='area1', title='Work Area', trashed=0)
+        TMArea.create(uuid='area2', title='Personal Area', trashed=0)
+        TMArea.create(uuid='area3', title='Trashed Area', trashed=1) 
+
+        areas = self.reader.get_areas()
+        self.assertEqual(len(areas), 2) 
+        self.assertIn({'uuid': 'area1', 'title': 'Work Area'}, [dict(a) for a in areas])
+        self.assertIn({'uuid': 'area2', 'title': 'Personal Area'}, [dict(a) for a in areas])
+
+    def test_get_projects(self):
+        area1 = TMArea.create(uuid='area1', title='Work')
+        TMTask.create(uuid='proj1', title='Project Alpha', type=1, area=area1, trashed=0, notes='Alpha notes') 
+        TMTask.create(uuid='proj2', title='Project Beta', type=1, trashed=0, notes='Beta notes') # No area
+        TMTask.create(uuid='proj3', title='Trashed Project', type=1, area=area1, trashed=1)
+
+
+        projects = self.reader.get_projects()
+        self.assertEqual(len(projects), 2)
+        
+        project_data_alpha = next(p for p in projects if p['uuid'] == 'proj1')
+        self.assertEqual(project_data_alpha['title'], 'Project Alpha')
+        self.assertEqual(project_data_alpha['area_uuid'], 'area1')
+        self.assertEqual(project_data_alpha['notes'], 'Alpha notes')
+
+        project_data_beta = next(p for p in projects if p['uuid'] == 'proj2')
+        self.assertEqual(project_data_beta['title'], 'Project Beta')
+        self.assertIsNone(project_data_beta['area_uuid'])
+
+
+    def test_get_tasks_for_project(self):
+        area1 = TMArea.create(uuid='area1', title='Work')
+        proj1 = TMTask.create(uuid='proj1', title='Project Alpha', type=1, area=area1, trashed=0)
+        # Tasks directly under project (no heading)
+        TMTask.create(uuid='task1', title='Task 1 for Proj1', type=0, project=proj1, trashed=0, notes="Task 1 notes", dueDate=datetime(2024,1,1))
+        TMTask.create(uuid='task2', title='Task 2 for Proj1 (trashed)', type=0, project=proj1, trashed=1)
+        # Task under a heading - should NOT be returned by this function
+        heading1 = TMTask.create(uuid='head1', title='Heading 1', type=2, project=proj1, trashed=0)
+        TMTask.create(uuid='task3', title='Task under Heading', type=0, project=proj1, heading=heading1, trashed=0)
+        
+        tasks = self.reader.get_tasks_for_project(project_uuid='proj1')
+        self.assertEqual(len(tasks), 1)
+        task_data = dict(tasks[0])
+        self.assertEqual(task_data['title'], 'Task 1 for Proj1')
+        self.assertEqual(task_data['notes'], 'Task 1 notes')
+        self.assertEqual(task_data['due_date'], datetime(2024,1,1))
+
+    def test_get_headings_for_project(self):
+        area1 = TMArea.create(uuid='area1', title='Work')
+        proj1 = TMTask.create(uuid='proj1', title='Project Alpha', type=1, area=area1, trashed=0)
+        TMTask.create(uuid='head1', title='Planning Phase', type=2, project=proj1, trashed=0)
+        TMTask.create(uuid='head2', title='Execution Phase', type=2, project=proj1, trashed=0)
+        TMTask.create(uuid='head3', title='Trashed Heading', type=2, project=proj1, trashed=1)
+
+        headings = self.reader.get_headings_for_project(project_uuid='proj1')
+        self.assertEqual(len(headings), 2)
+        heading_titles = [h['title'] for h in headings]
+        self.assertIn('Planning Phase', heading_titles)
+        self.assertIn('Execution Phase', heading_titles)
+
+    def test_get_tasks_for_heading(self):
+        area1 = TMArea.create(uuid='area1', title='Work')
+        proj1 = TMTask.create(uuid='proj1', title='Project Alpha', type=1, area=area1, trashed=0)
+        heading1 = TMTask.create(uuid='head1', title='Design Tasks', type=2, project=proj1, trashed=0)
+        TMTask.create(uuid='taskA', title='Draft UI', type=0, heading=heading1, project=proj1, trashed=0, notes="Draft notes", dueDate=datetime(2024,2,15))
+        TMTask.create(uuid='taskB', title='Review UI', type=0, heading=heading1, project=proj1, trashed=0)
+        TMTask.create(uuid='taskC', title='Trashed Task under Heading', type=0, heading=heading1, project=proj1, trashed=1)
+
+        tasks = self.reader.get_tasks_for_heading(heading_uuid='head1')
+        self.assertEqual(len(tasks), 2)
+        task_titles = [t['title'] for t in tasks]
+        self.assertIn('Draft UI', task_titles)
+        self.assertIn('Review UI', task_titles)
+        
+        task_a_data = next(t for t in tasks if t['uuid'] == 'taskA')
+        self.assertEqual(task_a_data['notes'], 'Draft notes')
+        self.assertEqual(task_a_data['due_date'], datetime(2024,2,15))
+
+
+    def test_get_tasks_standalone(self):
+        # Area and Project for context, but not directly linked to standalone tasks
+        area1 = TMArea.create(uuid='area1', title='Personal')
+        proj1 = TMTask.create(uuid='proj1', title='Home Reno', type=1, area=area1, trashed=0)
+        
+        # Standalone tasks (no project, some with area, some without)
+        TMTask.create(uuid='taskS1', title='Buy Groceries', type=0, area=area1, trashed=0, dueDate=datetime(2024,3,1))
+        TMTask.create(uuid='taskS2', title='Book Appointment', type=0, trashed=0) # No area
+        TMTask.create(uuid='taskS3', title='Trashed Standalone', type=0, area=area1, trashed=1)
+        
+        # Task belonging to a project - should NOT be in the main get_tasks() result if we interpret get_tasks() as "all non-project, non-heading tasks"
+        # However, the current implementation of get_tasks in ThingsReader fetches ALL tasks of type 0.
+        # This means it will include tasks that are part of projects as well.
+        # Let's test according to the current implementation.
+        TMTask.create(uuid='taskP1', title='Project Task 1', type=0, project=proj1, area=area1, trashed=0)
+
+        all_tasks = self.reader.get_tasks() # type=0, trashed=0
+        
+        # Expected: taskS1, taskS2, taskP1
+        self.assertEqual(len(all_tasks), 3) 
+        
+        task_titles = [t['title'] for t in all_tasks]
+        self.assertIn('Buy Groceries', task_titles)
+        self.assertIn('Book Appointment', task_titles)
+        self.assertIn('Project Task 1', task_titles)
+
+        task_s1_data = next(t for t in all_tasks if t['uuid'] == 'taskS1')
+        self.assertEqual(task_s1_data['area_uuid'], 'area1')
+        self.assertEqual(task_s1_data['due_date'], datetime(2024,3,1))
+        self.assertIsNone(task_s1_data['project_uuid']) # Standalone
+
+        task_s2_data = next(t for t in all_tasks if t['uuid'] == 'taskS2')
+        self.assertIsNone(task_s2_data['area_uuid'])
+        self.assertIsNone(task_s2_data['project_uuid']) # Standalone
+
+        task_p1_data = next(t for t in all_tasks if t['uuid'] == 'taskP1')
+        self.assertEqual(task_p1_data['project_uuid'], 'proj1') # Part of project
+
+    def test_no_data_scenarios(self):
+        self.assertEqual(self.reader.get_areas(), [])
+        self.assertEqual(self.reader.get_projects(), [])
+        self.assertEqual(self.reader.get_tasks(), [])
+        self.assertEqual(self.reader.get_headings_for_project('nonexistent_proj'), [])
+        self.assertEqual(self.reader.get_tasks_for_project('nonexistent_proj'), [])
+        self.assertEqual(self.reader.get_tasks_for_heading('nonexistent_head'), [])
+
+    def test_reader_initialization_file_not_found(self):
+        # Stop the init patcher to test the actual db.init call in ThingsReader's constructor
+        self.patcher_sqlite_db_init.stop() 
+        
+        # Patch os.path.exists to simulate file not found for the db_path
+        with patch('os.path.exists', return_value=False):
+            with self.assertRaises(FileNotFoundError):
+                ThingsReader(db_path="non_existent_path.sqlite")
+        
+        # Restart it for other tests if setUp is not run for each test method (though it is with unittest.TestCase)
+        self.patcher_sqlite_db_init.start() 
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a Python script to migrate data from the Things 3 application to Google Tasks.

Features:
- Migrates Things Areas to Google Task Lists.
- Migrates Things Projects to main Google Tasks, with their associated tasks and headings becoming subtasks.
- Handles Things Headings within projects by creating placeholder subtasks in Google Tasks.
- Provides a `--clean-slate` option to remove all pre-existing Google Tasks data before migration.
- Supports configuration via command-line arguments or a `config.py` file.
- Includes a comprehensive suite of unit tests for data reading, Google Tasks API interaction, and the main migration logic.
- Comes with a detailed README.md explaining setup, configuration, and usage.

The script utilizes the `pythings` approach of directly querying the Things SQLite database and the official Google Tasks API via the `google-api-python-client` library.